### PR TITLE
Fix issue with build links

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "eslint": "^1.2.1",
     "eslint-config-airbnb": "0.0.8",
     "mocha": "^2.2.5"
+  },
+  "dependencies": {
+    "qs": "^5.1.0"
   }
 }

--- a/spec/rest.spec.js
+++ b/spec/rest.spec.js
@@ -11,4 +11,45 @@ describe('Paging .addSelfLink', function() {
     restUtils.addSelfLink(item, '_id', rootUrl);
     expect(item).to.have.property('_links');
   });
+
+  it('should build link', function() {
+    const obj = {
+      data: {
+        list: [
+          {
+            id: 2,
+            name: 'question',
+            updatedAt: '2015-09-14T19:32:19.740Z',
+          },
+          {
+            id: 3,
+            name: 'question 2',
+            updatedAt: '2015-09-14T19:32:19.740Z',
+          },
+        ],
+      },
+      defaultSortField: {
+        column: '-q.updatedAt',
+        json: 'updatedAt',
+      },
+      idField: {
+        column: 'q.id',
+        json: 'id',
+      },
+      limit: 1,
+      query: {
+        limit: 1,
+        query: {
+          termId: 1,
+        },
+      },
+      queryBuilderType: 'knex',
+      root: '/questions',
+      sortFieldName: 'updatedAt',
+    };
+
+    restUtils.datePaged(obj);
+    const test = /query\%5BtermId\%5D=1/.test(obj.data._links.next.href);
+    expect(test).to.be.equal(true);
+  });
 });

--- a/src/rest.js
+++ b/src/rest.js
@@ -1,4 +1,4 @@
-import qs from 'querystring';
+import qs from 'qs';
 import { DIRECTION } from './search-providers/search-provider';
 
 
@@ -7,7 +7,6 @@ export function datePaged(opt) {
   const hasNext = existsNextLink(opt);
 
   removeRemainingItem(opt, hasPrev);
-
   if (hasPrev) buildLink(opt, DIRECTION.BACKWARD);
   if (hasNext) buildLink(opt, DIRECTION.FORWARD);
 }


### PR DESCRIPTION
Accessing one url with some sort of square brackets url it was not adding those in the links back...

e.g.

/questions?query[termId]=10

To fix it's using the qs module instead of querystring

Please when possible bump tag :beer: 
