### PR TITLE
Surround sort paging query with parenthesis

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "babel": "^5.8.21",
     "babel-eslint": "^4.0.10",
     "chai": "^3.2.0",
+    "escope": "3.3.0",
     "eslint": "^1.2.1",
     "eslint-config-airbnb": "0.0.8",
     "mocha": "^2.2.5"

--- a/src/search-providers/knex.js
+++ b/src/search-providers/knex.js
@@ -27,11 +27,14 @@ export default class KnexSearchProvider extends SearchProvider {
     }
 
     knex
-      .where(this.sortFieldColumn, operator, this.offsetPrimaryField)
-      .where(this.idFieldColumn, '<>', this.query.offset_id)
-      .orWhere((query) => {
-        query.where(this.sortFieldColumn, this.offsetPrimaryField);
-        query.where(this.idFieldColumn, operator, this.query.offset_id);
+      .where((query) => {
+        query
+          .where(this.sortFieldColumn, operator, this.offsetPrimaryField)
+          .where(this.idFieldColumn, '<>', this.query.offset_id)
+          .orWhere((orQuery) => {
+            orQuery.where(this.sortFieldColumn, this.offsetPrimaryField);
+            orQuery.where(this.idFieldColumn, operator, this.query.offset_id);
+          });
       });
   }
 }

--- a/src/search-providers/knex.js
+++ b/src/search-providers/knex.js
@@ -29,8 +29,11 @@ export default class KnexSearchProvider extends SearchProvider {
     knex
       .where((query) => {
         query
-          .where(this.sortFieldColumn, operator, this.offsetPrimaryField)
-          .where(this.idFieldColumn, '<>', this.query.offset_id)
+          .where((andWhere) => {
+            andWhere.where(this.sortFieldColumn, operator,
+              this.offsetPrimaryField);
+            andWhere.where(this.idFieldColumn, '<>', this.query.offset_id);
+          })
           .orWhere((orQuery) => {
             orQuery.where(this.sortFieldColumn, this.offsetPrimaryField);
             orQuery.where(this.idFieldColumn, operator, this.query.offset_id);


### PR DESCRIPTION
This PR fixes an issue when generate sort query. The sort query was directly added to the main query instead of being surrounded by parenthesis.

``` sql
-- before
select ... from ... where some_field = ? and offset_date > ? and id <> ? or (offset_date = ? and id > ?)
-- after
select ... from ... where some_field = ? and (offset_date > ? and id <> ? or (offset_date = ? and id > ?))
```
